### PR TITLE
Changed "coreProcessorCortex" to "coreProcessor"

### DIFF
--- a/part-spec/ic_micro.json
+++ b/part-spec/ic_micro.json
@@ -30,8 +30,8 @@
                     "comment": "units of kilobytes",
                     "$ref": "definitions.json#/unit"
                 },
-                "coreProcessorCortex": {
-                    "description": "description of core processor cortex",
+                "coreProcessor": {
+                    "description": "description of core processor",
                     "examples": [
                         "Cortex-M4"
                     ],


### PR DESCRIPTION
Changed the "coreProcessorCortex" property to a general "coreProcessor" property since other core architectures can be used in the microcontroller.