### PR TITLE
ic_micro: fix incorrect type of package.

### DIFF
--- a/part-spec/ic_micro.json
+++ b/part-spec/ic_micro.json
@@ -72,10 +72,8 @@
                 },
                 "package": {
                     "description": "component's package size and description",
-                     "items": {
-                        "$ref": "definitions.json#/package"
-                        }
-                    }
+                    "$ref": "definitions.json#/package"
+                }
             }
         }
     ]


### PR DESCRIPTION
the prior version seems like a mistake since it is different than all the other package fields in other specs I looked at.