### PR TITLE
definitions: ensure all types are in the "definitions" field.

### DIFF
--- a/part-spec/definitions.json
+++ b/part-spec/definitions.json
@@ -391,254 +391,252 @@
           ]
         }
       }
-    }
-  },
-  "unit": {
-    "type": "object",
-    "properties": {
-      "siUnit": {
-        "description": "name of SI unit of measure",
-        "enum": [
-          "volt",
-          "amp",
-          "ohm",
-          "coulomb",
-          "henry",
-          "farad",
-          "second",
-          "watt",
-          "joule",
-          "celsius",
-          "meter",
-          "gram",
-          "hertz",
-          "percentage",
-          "bit",
-          "byte"
-        ],
-        "type": "string"
-      },
-      "absoluteValue": {
-        "description": "unit quantity corresponding to unit text - example 40mV would have a value of 40",
-        "type": "number"
-      },
-      "unitText": {
-        "description": "human readable text describing value - example 40mV would have a value of mV",
-        "type": "string"
-      },
-      "unitFactor": {
-        "description": "multiplier on the value to achieve the SI unit - example for 40mV the unitFactor would be 0.001",
-        "type": "number"
-      },
-      "relativeValueReference": {
-        "description": "if unit quantity is based on another reference, value of the reference",
-        "example": "VDD1",
-        "type": "string"
-      },
-      "relativeValueModifier": {
-        "description": "if a unit quantity is based on another reference, the value that edits that reference",
-        "example": "1.2",
-        "type": "number"
-      },
-      "relativeValueOperator": {
-        "description": "if a unit quantity is based on another reference, the operation that is performed with the modifier",
-        "example": "multiply",
-        "type": "string",
-        "enum": [
-          "multiply",
-          "add",
-          "subtract"
-        ]
-      },
-      "valueDefined": {
-        "description": "a boolean representing whether a value has been defined",
-        "type": "boolean"
+    },
+    "unit": {
+      "type": "object",
+      "properties": {
+        "siUnit": {
+          "description": "name of SI unit of measure",
+          "enum": [
+            "volt",
+            "amp",
+            "ohm",
+            "coulomb",
+            "henry",
+            "farad",
+            "second",
+            "watt",
+            "joule",
+            "celsius",
+            "meter",
+            "gram",
+            "hertz",
+            "percentage",
+            "bit",
+            "byte"
+          ],
+          "type": "string"
+        },
+        "absoluteValue": {
+          "description": "unit quantity corresponding to unit text - example 40mV would have a value of 40",
+          "type": "number"
+        },
+        "unitText": {
+          "description": "human readable text describing value - example 40mV would have a value of mV",
+          "type": "string"
+        },
+        "unitFactor": {
+          "description": "multiplier on the value to achieve the SI unit - example for 40mV the unitFactor would be 0.001",
+          "type": "number"
+        },
+        "relativeValueReference": {
+          "description": "if unit quantity is based on another reference, value of the reference",
+          "example": "VDD1",
+          "type": "string"
+        },
+        "relativeValueModifier": {
+          "description": "if a unit quantity is based on another reference, the value that edits that reference",
+          "example": "1.2",
+          "type": "number"
+        },
+        "relativeValueOperator": {
+          "description": "if a unit quantity is based on another reference, the operation that is performed with the modifier",
+          "example": "multiply",
+          "type": "string",
+          "enum": [
+            "multiply",
+            "add",
+            "subtract"
+          ]
+        },
+        "valueDefined": {
+          "description": "a boolean representing whether a value has been defined",
+          "type": "boolean"
+        }
       }
-    }
-  },
-  "package": {
-    "type": "object",
-    "properties": {
-      "length": {
-        "description": "length of a side of a package",
-        "type": "number"
-      },
-      "width": {
-        "description": "width of a side of a package",
-        "type": "number"
-      },
-      "height": {
-        "description": "height of a package",
-        "type": "number"
-      },
-      "dimensionUnit": {
-        "description": "unit used to describe package dimensions",
-        "enum": [
-          "mils",
-          "millimeter"
-        ]
-      },
-      "standardPackageSize": {
-        "description": "name of standard package size (imperial)",
-        "enum": [
-          "0201",
-          "0402",
-          "0603",
-          "0805",
-          "1206"
-        ]
-      },
-      "standardPackageType": {
-        "description": "name of standard package types",
-        "example": [
-          "bga",
-          "wcsp",
-          "qfn",
-          "tssop"
-        ]
+    },
+    "package": {
+      "type": "object",
+      "properties": {
+        "length": {
+          "description": "length of a side of a package",
+          "type": "number"
+        },
+        "width": {
+          "description": "width of a side of a package",
+          "type": "number"
+        },
+        "height": {
+          "description": "height of a package",
+          "type": "number"
+        },
+        "dimensionUnit": {
+          "description": "unit used to describe package dimensions",
+          "enum": [
+            "mils",
+            "millimeter"
+          ]
+        },
+        "standardPackageSize": {
+          "description": "name of standard package size (imperial)",
+          "enum": [
+            "0201",
+            "0402",
+            "0603",
+            "0805",
+            "1206"
+          ]
+        },
+        "standardPackageType": {
+          "description": "name of standard package types",
+          "example": [
+            "bga",
+            "wcsp",
+            "qfn",
+            "tssop"
+          ]
+        }
       }
-    }
-  },
-  "conditionalProperty": {
-    "type": "object",
-    "properties": {
-      "value": {
-        "description": "value of property",
-        "$ref": "#/$definitions/unit"
-      },
-      "conditions": {
-        "description": "conditions under which the property is measured",
-        "type": "array",
-        "items": "string"
+    },
+    "conditionalProperty": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "value of property",
+          "$ref": "#/$definitions/unit"
+        },
+        "conditions": {
+          "description": "conditions under which the property is measured",
+          "type": "array",
+          "items": "string"
+        }
       }
-    }
-  },
-  "currentConsumption": {
-    "type": "object",
-    "properties": {
-      "supplyName": {
-        "description": "Name of the power supply ",
-        "type": "string"
-      },
-      "quiescentCurrentTyp": {
-        "description": "typical quiescent current (Iq) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "quiescentCurrentMax": {
-        "description": "maximum quiescent current (Iq) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "quiescentCurrentMin": {
-        "description": "minimum quiescent current (Iq) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "shutdownCurrentTyp": {
-        "description": "typical shutdown current (Isd) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "shutdownCurrentMax": {
-        "description": "maximum shutdown current (Isd) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "shutdownCurrentMin": {
-        "description": "minimum shutdown current (Isd) of a device",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "activeCurrentTyp": {
-        "description": "typical current consumption when a device is in active mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "activeCurrentMax": {
-        "description": "maximum current consumption when a device is in active mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "activeCurrentMin": {
-        "description": "minimum current consumption when a device is in active mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "sleepCurrentTyp": {
-        "description": "typical current consumption when a device is in sleep mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "sleepCurrentMax": {
-        "description": "maximum current consumption when a device is in sleep mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "sleepCurrentMin": {
-        "description": "minimum current consumption when a device is in sleep mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "idleCurrentTyp": {
-        "description": "typical current consumption when a device is in idle mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "idleCurrentMax": {
-        "description": "maximum current consumption when a device is in idle mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
-      },
-      "idleCurrentMin": {
-        "description": "minimum current consumption when a device is in idle mode",
-        "comment": "units of amps",
-        "$ref": "definitions.json#/unit"
+    },
+    "currentConsumption": {
+      "type": "object",
+      "properties": {
+        "supplyName": {
+          "description": "Name of the power supply ",
+          "type": "string"
+        },
+        "quiescentCurrentTyp": {
+          "description": "typical quiescent current (Iq) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "quiescentCurrentMax": {
+          "description": "maximum quiescent current (Iq) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "quiescentCurrentMin": {
+          "description": "minimum quiescent current (Iq) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "shutdownCurrentTyp": {
+          "description": "typical shutdown current (Isd) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "shutdownCurrentMax": {
+          "description": "maximum shutdown current (Isd) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "shutdownCurrentMin": {
+          "description": "minimum shutdown current (Isd) of a device",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "activeCurrentTyp": {
+          "description": "typical current consumption when a device is in active mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "activeCurrentMax": {
+          "description": "maximum current consumption when a device is in active mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "activeCurrentMin": {
+          "description": "minimum current consumption when a device is in active mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "sleepCurrentTyp": {
+          "description": "typical current consumption when a device is in sleep mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "sleepCurrentMax": {
+          "description": "maximum current consumption when a device is in sleep mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "sleepCurrentMin": {
+          "description": "minimum current consumption when a device is in sleep mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "idleCurrentTyp": {
+          "description": "typical current consumption when a device is in idle mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "idleCurrentMax": {
+          "description": "maximum current consumption when a device is in idle mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        },
+        "idleCurrentMin": {
+          "description": "minimum current consumption when a device is in idle mode",
+          "comment": "units of amps",
+          "$ref": "definitions.json#/unit"
+        }
       }
-    }
-  },
-  "instances": {
-    "type": "object",
-    "properties": {
-      "componentTitle": {
-        "description": "title used for the component in the digital datasheets specifications",
-        "type": "string"
-      },
-      "instanceName": {
-        "description": "name of component instances",
-        "type": "string"
-      },
-      "instanceProperties": {
-        "description": "definition of the component instance as defined in the speci2fications",
-        "type": "array"
+    },
+    "instances": {
+      "type": "object",
+      "properties": {
+        "componentTitle": {
+          "description": "title used for the component in the digital datasheets specifications",
+          "type": "string"
+        },
+        "instanceName": {
+          "description": "name of component instances",
+          "type": "string"
+        },
+        "instanceProperties": {
+          "description": "definition of the component instance as defined in the speci2fications",
+          "type": "array"
+        }
       }
-    }
-  },
-  "componentProtectionThresholds": {
-    "type": "object",
-    "properties": {
-      "thermalShutdownThresholdRising": {
-        "description": "Thermal Shutdown (tsd) Threshold with temperature rising",
-        "comment": "units of celsius",
-        "$ref": "definitions.json#/unit"
-      },
-      "thermalShutdownThresholdFalling": {
-        "description": "Thermal Shutdown (tsd) Threshold with temperature falling",
-        "comment": "units of celsius",
-        "$ref": "definitions.json#/unit"
-      },
-      "thermalShutdownHysteresis": {
-        "description": "Thermal Shutdown (tsd) Hysteresis",
-        "comment": "units of celsius",
-        "$ref": "definitions.json#/unit"
-      },
-      "powerSupplyProtection": {
-        "description": "undervoltage lockout, overvoltage protection thresholds of a supply",
-        "$ref": "#/defs/powerSupplyProtection"
+    },
+    "componentProtectionThresholds": {
+      "type": "object",
+      "properties": {
+        "thermalShutdownThresholdRising": {
+          "description": "Thermal Shutdown (tsd) Threshold with temperature rising",
+          "comment": "units of celsius",
+          "$ref": "definitions.json#/unit"
+        },
+        "thermalShutdownThresholdFalling": {
+          "description": "Thermal Shutdown (tsd) Threshold with temperature falling",
+          "comment": "units of celsius",
+          "$ref": "definitions.json#/unit"
+        },
+        "thermalShutdownHysteresis": {
+          "description": "Thermal Shutdown (tsd) Hysteresis",
+          "comment": "units of celsius",
+          "$ref": "definitions.json#/unit"
+        },
+        "powerSupplyProtection": {
+          "description": "undervoltage lockout, overvoltage protection thresholds of a supply",
+          "$ref": "#/defs/powerSupplyProtection"
+        }
       }
-    }
-  },
-  "$defs": {
+    },
     "powerSupplyProtection": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
It looks like some of the types were in a "$defs" field and some were just in the root object. This change moves everything into the "definitions" field where all the other objects are found.