### PR TITLE
add oscillator definition

### DIFF
--- a/part-spec/clock_oscillators.json
+++ b/part-spec/clock_oscillators.json
@@ -1,0 +1,87 @@
+{
+    "$id": "https://github.com/chromeos/digital-datasheets/blob/main/part-spec/hardware.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "clock_oscillators",
+    "oneOf": [
+        {
+            "title": "oscillator",
+            "type": "object",
+            "required": [
+                "componentID",
+                "frequency"
+            ],
+            "properties": {
+                "componentID": {
+                    "description": "common component identifying information, such as mpn.",
+                    "$ref": "definitions.json#/componentID"
+                },
+                "baseResonator": {
+                    "description": "technology producing resonance",
+                    "type": "string",
+                    "enum": [
+                        "crystal",
+                        "mems",
+                        "silicon"
+                    ]
+                },
+                "frequency": {
+                    "description": "output frequency of oscillator",
+                    "$comment": "units of hertz",
+                    "$ref": "definitions.json#/unit"
+                },
+                "frequencyStability": {
+                    "description": "Frequency change over temperature, load, supply voltage change and aging",
+                    "$comment": "units of ppm",
+                    "$type": "number"
+                },
+                "currentConsumption": {
+                    "description": "current consumption of a device",
+                    "comment": "units of amps",
+                    "$ref": "definitions.json#/currentConsumption"
+                },
+                "outputLoad": {
+                    "description": "maxium capacitive load that can be supported by oscillator",
+                    "comment": "units of farads",
+                    "$ref": "definitions.json#/unit"
+                },
+                "riseTime": {
+                    "description": "time for output to go from 10% to 90% of output max",
+                    "comment": "units of seconds",
+                    "$ref": "definitions.json#/unit"
+                },
+                "fallTime": {
+                    "description": "time for output to go from 90% to 10% of output max",
+                    "comment": "units of seconds",
+                    "$ref": "definitions.json#/unit"
+                },
+                "startUpTime": {
+                    "description": "time between enable and output reaching 10% of output max",
+                    "comment": "units of seconds",
+                    "$ref": "definitions.json#/unit"
+                },
+                "dutyCycle": {
+                    "description": "time above 50% of output max over entire period",
+                    "comment": "units of percent",
+                    "$ref": "definitions.json#/unit"
+                },
+                "phaseJitter": {
+                    "description": "variation of waveform period",
+                    "comment": "units of seconds",
+                    "$ref": "definitions.json#/unit"
+                },
+                "pins": {
+                    "description": "array of pin objects with associated properties",
+                    "type": "array",
+                    "items": {
+                        "$ref": "definitions.json#/pinSpec"
+                    }
+                },
+                "package": {
+                    "description": "component's package size and description",
+                    "$ref": "definitions.json#/package"
+                }
+            }
+        }
+    ]
+}

--- a/part-spec/clock_oscillators.json
+++ b/part-spec/clock_oscillators.json
@@ -68,7 +68,7 @@
                 "phaseJitter": {
                     "description": "variation of waveform period",
                     "comment": "units of seconds",
-                    "$ref": "definitions.json#/unit"
+                    "$ref": "definitions.json#/conditionalProperty"
                 },
                 "pins": {
                     "description": "array of pin objects with associated properties",


### PR DESCRIPTION
This commit adds oscillator definition which covers mems, silicon, and cmos based oscillators.