### PR TITLE
reorganize component to include multi-file support, include example

### DIFF
--- a/part-spec/adc_dac.json
+++ b/part-spec/adc_dac.json
@@ -7,14 +7,7 @@
         {
             "title": "adc",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "digitalResolution": {
                     "description": "number of bits of resolution in the digital output",
                     "type": "number"
@@ -85,31 +78,13 @@
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         },
         {
             "title": "dac",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "digitalResolution": {
                     "description": "number of bits of resolution",
                     "type": "number"
@@ -170,17 +145,6 @@
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         }

--- a/part-spec/clock_oscillators.json
+++ b/part-spec/clock_oscillators.json
@@ -8,14 +8,9 @@
             "title": "oscillator",
             "type": "object",
             "required": [
-                "componentID",
                 "frequency"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn.",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "baseResonator": {
                     "description": "technology producing resonance",
                     "type": "string",
@@ -69,17 +64,6 @@
                     "description": "variation of waveform period",
                     "comment": "units of seconds",
                     "$ref": "conditionalProperty.json#/conditionalProperty"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         }

--- a/part-spec/component.json
+++ b/part-spec/component.json
@@ -11,8 +11,8 @@
 			"description": "methods for identifying the version of the digital datasheet",
 			"$ref": "componentID.json#/componentID"
 		},
-		"coreProperities": {
-			"description": "core component properities as definied by the specific component spec file",
+		"coreProperties": {
+			"description": "core component properties as definied by the specific component spec file",
 			"type": "object"
 		},
 		"pins": {
@@ -27,7 +27,7 @@
 			"$ref": "package.json#/package"
 		},
 		"externalFileMap": {
-			"description": "external files that describe key component properities. External files can be used in lieu of defining core properities, pins, and package informatoin in the same file",
+			"description": "external files that describe key component properties. External files can be used in lieu of defining core properties, pins, and package informatoin in the same file",
 			"$ref": "#/$defs/externalFileMap"
 		}
 	},
@@ -35,18 +35,18 @@
 		"externalFileMap": {
 			"type": "object",
 			"properties": {
-				"coreProperities": {
-					"description": "core component properities as definied by the specific component spec file. These properities are described by the common part of the part number",
+				"coreProperties": {
+					"description": "core component properties as definied by the specific component spec file. These properties are described by the common part of the part number",
 					"example": "this might include everything about an MCU other than flash size",
 					"$ref": "externalFile.json#/externalFile"
 				},
 				"additionalCoreProperities": {
-					"description": "core component properities as definied by the specific component spec file. These properities are described by the changing part of the part number",
+					"description": "core component properties as definied by the specific component spec file. These properties are described by the changing part of the part number",
 					"example": "this might include the MCU flash size",
 					"$ref": "externalFile.json#/externalFile"
 				},
 				"pins": {
-					"description": "pin properities specified by the pin spec file",
+					"description": "pin properties specified by the pin spec file",
 					"$ref": "externalFile.json#/externalFile"
 				},
 				"package": {

--- a/part-spec/component.json
+++ b/part-spec/component.json
@@ -11,11 +11,48 @@
 			"description": "methods for identifying the version of the digital datasheet",
 			"$ref": "componentID.json#/componentID"
 		},
+		"coreProperities": {
+			"description": "core component properities as definied by the specific component spec file",
+			"type": "object"
+		},
 		"pins": {
 			"description": "array of pin objects with associated properties",
 			"type": "array",
 			"items": {
 				"$ref": "pinSpec.json#/pinSpec"
+			}
+		},
+		"package": {
+			"description": "component package information",
+			"$ref": "package.json#/package"
+		},
+		"externalFileMap": {
+			"description": "external files that describe key component properities. External files can be used in lieu of defining core properities, pins, and package informatoin in the same file",
+			"$ref": "#/$defs/externalFileMap"
+		}
+	},
+	"$defs": {
+		"externalFileMap": {
+			"type": "object",
+			"properties": {
+				"coreProperities": {
+					"description": "core component properities as definied by the specific component spec file. These properities are described by the common part of the part number",
+					"example": "this might include everything about an MCU other than flash size",
+					"$ref": "externalFile.json#/externalFile"
+				},
+				"additionalCoreProperities": {
+					"description": "core component properities as definied by the specific component spec file. These properities are described by the changing part of the part number",
+					"example": "this might include the MCU flash size",
+					"$ref": "externalFile.json#/externalFile"
+				},
+				"pins": {
+					"description": "pin properities specified by the pin spec file",
+					"$ref": "externalFile.json#/externalFile"
+				},
+				"package": {
+					"description": "package information specified by the package spec file",
+					"$ref": "externalFile.json#/externalFile"
+				}
 			}
 		}
 	}

--- a/part-spec/componentID.json
+++ b/part-spec/componentID.json
@@ -37,8 +37,11 @@
                 "type": "string"
             },
             "orderableMPN": {
-                "description": "orderable manufacturer part number",
-                "type": "string"
+                "description": "orderable manufacturer part numbers, including packing and software information",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             },
             "sourceDatasheetID": {
                 "description": "methods for identifying the human-readable source information for a digital datasheet",

--- a/part-spec/externalFile.json
+++ b/part-spec/externalFile.json
@@ -1,41 +1,43 @@
-"$id": "https://github.com/edatasheets/edatasheets.github.io/blob/main/part-spec/externalFile.json",
-"$schema": "http://json-schema.org/draft-07/schema#",
-"title": "Specification for referencing an external file",
-"package": {
-    "type": "object",
-    "properties": {
-        "fileDescription": {
-            "description": "text description of the contents of an external file",
-            "type": "string"
-        },
-        "fileType": {
-            "description": "type of file being linked",
-            "examples": [
-                "brd",
-                "ibis",
-                "json"
-            ],
-            "type": "string"
-        },
-        "fileExtension": {
-            "description": "extension of file linked",
-            "examples": [
-                "brd",
-                "mod"
-            ],
-            "type": "string"
-        },
-        "companionSoftware": {
-            "description": "optional, name of software program used to access file",
-            "type": "string"
-        },
-        "standardReferenced": {
-            "description": "optional, name of the standard the file is written in",
-            "type": "string"
-        },
-        "fileURI": {
-            "description": "URI linking to the CAD file",
-            "type": "string"
+{
+    "$id": "https://github.com/edatasheets/edatasheets.github.io/blob/main/part-spec/externalFile.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Specification for referencing an external file",
+    "externalFile": {
+        "type": "object",
+        "properties": {
+            "fileDescription": {
+                "description": "text description of the contents of an external file",
+                "type": "string"
+            },
+            "fileType": {
+                "description": "type of file being linked",
+                "examples": [
+                    "brd",
+                    "ibis",
+                    "json"
+                ],
+                "type": "string"
+            },
+            "fileExtension": {
+                "description": "extension of file linked",
+                "examples": [
+                    "brd",
+                    "mod"
+                ],
+                "type": "string"
+            },
+            "companionSoftware": {
+                "description": "optional, name of software program used to access file",
+                "type": "string"
+            },
+            "standardReferenced": {
+                "description": "optional, name of the standard the file is written in",
+                "type": "string"
+            },
+            "fileURI": {
+                "description": "URI linking to the CAD file",
+                "type": "string"
+            }
         }
     }
 }

--- a/part-spec/externalFile.json
+++ b/part-spec/externalFile.json
@@ -36,6 +36,7 @@
             },
             "fileURI": {
                 "description": "URI linking to the CAD file",
+                "example": "could be a URL or file path with filename",
                 "type": "string"
             }
         }

--- a/part-spec/ic_io.json
+++ b/part-spec/ic_io.json
@@ -7,14 +7,7 @@
         {
             "title": "redriver",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "numberChannels": {
                     "description": "number of lanes (single ended or differential) supported by redriver",
                     "type": "number"
@@ -36,34 +29,16 @@
                     "comment": "units of Hz",
                     "$ref": "unit.json#/unit"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "retimer",
             "type": "object",
-            "required": [
-             "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "numberOfLanes": {
                     "description": "number of lanes supported by a device",
                     "type": "number"
@@ -115,34 +90,16 @@
                     "description": "whether a device supports Seperate Reference clock with No Spread spectrum clocking (SRNS)",
                     "type": "boolean"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                    "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
-        },        
+        },
         {
             "title": "bridge chip",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "muxRatio": {
                     "description": "ratio of inputs to outputs",
                     "examples": [
@@ -173,31 +130,13 @@
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "mux",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "muxRatio": {
                     "description": "ratio of inputs to outputs",
                     "$ref": "ratio.json#/ratio"
@@ -212,41 +151,22 @@
                     "items": {
                         "type": "string"
                     }
-                    
                 },
                 "insertionLoss": {
                     "description": "insertion loss through mux",
                     "comment": "units of dB",
                     "type": "number"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "level shifter",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "inputVoltage": {
                     "description": "input voltage level of level shifter",
                     "comment": "units of volts",
@@ -257,20 +177,9 @@
                     "comment": "units of volts",
                     "$ref": "unit.json#/unit"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/ic_logic.json
+++ b/part-spec/ic_logic.json
@@ -8,14 +8,9 @@
             "title": "logic gate",
             "type": "object",
             "required": [
-                "componentID",
                 "type"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "type": {
                     "description": "logical operation performed by logic gate",
                     "enum": [
@@ -49,34 +44,16 @@
                     "comment": "units of seconds",
                     "$ref": "units.json#/unit"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "clock",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "fixedFrequency": {
                     "description": "clock frequency value if the clock has a fixed frequency",
                     "comment": "units of Hz",
@@ -119,20 +96,9 @@
                     ],
                     "type": "string"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/ic_micro.json
+++ b/part-spec/ic_micro.json
@@ -7,14 +7,7 @@
         {
             "title": "microcontroller/ec",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "onChipFlash": {
                     "description": "quantity of built-in flash in a microprocessor",
                     "comment": "units of kilobytes",
@@ -66,17 +59,6 @@
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         }

--- a/part-spec/ic_misc.json
+++ b/part-spec/ic_misc.json
@@ -7,14 +7,7 @@
         {
             "title": "speaker amplifier",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "dataLength": {
                     "description": "number of bits in a data word",
                     "type": "number"
@@ -48,34 +41,16 @@
                     ],
                     "type": "string"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "audio codec",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "dataLength": {
                     "description": "number of bits in a data word",
                     "type": "number"
@@ -113,34 +88,16 @@
                     ],
                     "type": "string"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "wlan module",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "wlanSpec": {
                     "description": "version of wlan specification supported by module",
                     "examples": [
@@ -200,34 +157,16 @@
                     ],
                     "type": "string"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "wwan module",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "networkSupport": {
                     "description": "networks supported by wwan module",
                     "enum": [
@@ -265,34 +204,16 @@
                     ],
                     "type": "string"
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "tpm",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "interface": {
                     "description": "describes the communication interface from the chip to the host",
                     "examples": [
@@ -305,20 +226,9 @@
                         "type": "string"
                     }
                 },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
                 "currentConsumption": {
                     "description": "current used by device in various power modes",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/led.json
+++ b/part-spec/led.json
@@ -7,14 +7,7 @@
         {
             "title": "LED",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn.",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "ledColor": {
                     "description": "LED color",
                     "examples": [
@@ -46,7 +39,7 @@
                 },
                 "ir": {
                     "description": "reverse current (leakage) of an LED",
-                    "comment": "conditions include: reverse biased voltage under which LED ir was measured", 
+                    "comment": "conditions include: reverse biased voltage under which LED ir was measured",
                     "$ref": "conditionalProperty.json#/conditionalProperty"
                 },
                 "ledCapacitance": {
@@ -73,22 +66,11 @@
                     "description": " angle at which LED intensity falls to 50% of its maximum value",
                     "$comment": "units of degrees",
                     "$ref": "unit.json#/unit"
-                },          
+                },
                 "pd": {
                     "description": "power dissipation of an LED",
                     "$comment": "units of milliwatts (mW)",
                     "$ref": "unit.json#/unit"
-                },
-                "package": {
-                    "description": "package size of LED",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/passives.json
+++ b/part-spec/passives.json
@@ -8,21 +8,9 @@
             "title": "resistor",
             "type": "object",
             "required": [
-                "componentID",
                 "value"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
                 "value": {
                     "description": "resistor value",
                     "comment": "units of ohms",
@@ -66,10 +54,6 @@
                 "resistorDerating": {
                     "description": "graph object to capture resistance changes with temperature",
                     "$ref": "graph.json#/graph"
-                },
-                "package": {
-                    "description": "package size of resistor",
-                    "$ref": "package.json#/package"
                 }
             }
         },
@@ -77,21 +61,9 @@
             "title": "capacitor",
             "type": "object",
             "required": [
-                "componentID",
                 "value"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
                 "value": {
                     "description": "capacitor value",
                     "comment": "units of farads",
@@ -143,10 +115,6 @@
                 "capacitorDerating": {
                     "description": "graph object to capture capacitance changes with voltage",
                     "$ref": "graph.json#/graph"
-                },
-                "package": {
-                    "description": "package size of capacitor",
-                    "$ref": "package.json#/package"
                 }
             }
         },
@@ -154,21 +122,9 @@
             "title": "inductor",
             "type": "object",
             "required": [
-                "componentID",
                 "value"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
                 "value": {
                     "description": "inductor value",
                     "comment": "units of henry",
@@ -226,24 +182,13 @@
                 "resonantFrequencyCurve": {
                     "description": "graph object to capture inductor resonant frequency",
                     "$ref": "graph.json#/graph"
-                },
-                "package": {
-                    "description": "package size of inductor",
-                    "$ref": "package.json#/package"
                 }
             }
         },
         {
             "title": "common mode choke",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "diffModeCutoff": {
                     "description": "frequency at which the differential mode attenuation equals -3dB",
                     "comment": "units of Hz",
@@ -271,31 +216,13 @@
                         "LVDS"
                     ],
                     "type": "string"
-                },
-                "package": {
-                    "description": "package size of device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "ferrite bead",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "dcResistance": {
                     "description": "dc resistance (DCR) of ferrite bead",
                     "comment": "units of ohms",
@@ -315,21 +242,8 @@
                     "description": "variation of ferrite bead impedance expressed as +/- percentage",
                     "comment": "units of percentage",
                     "$ref": "unit.json#/unit"
-                },
-                "package": {
-                    "description": "package size of device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }
     ]
 }
-        
-    

--- a/part-spec/power.json
+++ b/part-spec/power.json
@@ -8,17 +8,12 @@
       "title": "switching regulator",
       "type": "object",
       "required": [
-        "componentID",
         "regulatorTopology",
         "vin",
         "vout",
         "loadCurrent"
       ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "regulatorTopology": {
           "description": "switching voltage regulator topology",
           "examples": [
@@ -99,17 +94,6 @@
         "efficiency": {
           "description": "power efficiency of regulator",
           "$ref": "graph.json#/graph"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
-        },
-        "package": {
-          "description": "component's package size and description",
-          "$ref": "package.json#/package"
         }
       }
     },
@@ -117,16 +101,11 @@
       "title": "ldo",
       "type": "object",
       "required": [
-        "componentID",
         "vin",
         "vout",
         "loadCurrent"
       ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "vin": {
           "description": "input voltage under which the part can be expected to operate without the output dropping",
           "comment": "units of volts",
@@ -201,17 +180,6 @@
         "componentProtectionThresholds": {
           "description": "Thermal and power supply protection thresholds of a device",
           "$ref": "componentProtectionThresholds.json#/componentProtectionThresholds"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
-        },
-        "package": {
-          "description": "component's package size and description",
-          "$ref": "package.json#/package"
         }
       }
     },
@@ -219,16 +187,11 @@
       "title": "load switch",
       "type": "object",
       "required": [
-        "componentID",
         "vin",
         "outputCurrent",
         "onResistance"
       ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "fetType": {
           "description": "type of pass FET in a device",
           "enum": [
@@ -308,31 +271,13 @@
         "componentProtectionThresholds": {
           "description": "Thermal and power supply protection thresholds of a device",
           "$ref": "componentProtectionThresholds.json#/componentProtectionThresholds"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
-        },
-        "package": {
-          "description": "component's package size and description",
-          "$ref": "package.json#/package"
         }
       }
     },
     {
       "title": "pmic",
       "type": "object",
-      "required": [
-        "componentID"
-      ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "ldoRegulatorCount": {
           "description": "number of ldos in the device",
           "type": "number"
@@ -372,7 +317,10 @@
         "componentList": {
           "description": "List, by title, of components in the device",
           "comment": "list should only include components with an existing digital datasheet specification",
-          "type": "array of strings"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "instances": {
           "description": "definition of each instance of a component in the device",
@@ -393,17 +341,6 @@
         "componentProtectionThresholds": {
           "description": "Thermal and power supply protection thresholds of a device",
           "$ref": "componentProtectionThresholds.json#/componentProtectionThresholds"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
-        },
-        "package": {
-          "description": "component's package size and description",
-          "$ref": "package.json#/package"
         }
       }
     },
@@ -411,15 +348,10 @@
       "title": "display backlight driver",
       "type": "object",
       "required": [
-        "componentID",
         "iout",
         "vin"
       ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "vin": {
           "description": "input voltage under which a device can be expected to operate properly",
           "comment": "units of volts",
@@ -490,17 +422,6 @@
         "efficiency": {
           "description": "efficiency vs forward current",
           "$ref": "graph.json#/graph"
-        },
-        "package": {
-          "description": "package size",
-          "$ref": "package.json#/package"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
         }
       }
     },
@@ -508,14 +429,9 @@
       "title": "battery charger",
       "type": "object",
       "required": [
-        "componentID",
         "batteryChargeCurrent"
       ],
       "properties": {
-        "componentID": {
-          "description": "common component identifying information, such as mpn",
-          "$ref": "componentID.json#/componentID"
-        },
         "chargerType": {
           "description": "battery charger type",
           "examples": [
@@ -722,17 +638,6 @@
             "pd3.1"
           ],
           "type": "string"
-        },
-        "pins": {
-          "description": "array of pin objects with associated properties",
-          "type": "array",
-          "items": {
-            "$ref": "pinSpec.json#/pinSpec"
-          }
-        },
-        "package": {
-          "description": "component's package size and description",
-          "$ref": "package.json#/package"
         }
       }
     }

--- a/part-spec/semiconductor.json
+++ b/part-spec/semiconductor.json
@@ -8,15 +8,10 @@
             "title": "mosfet",
             "type": "object",
             "required": [
-                "componentID",
                 "mosfetType",
                 "channel"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn.",
-                    "$ref": "componenentID.json#/componentID"
-                },
                 "mosfetType": {
                     "description": "type of MOSFET.",
                     "examples": [
@@ -209,31 +204,13 @@
                 "pdVsTemp": {
                     "description": "graph of power dissipation vs temperature.",
                     "$ref": "graph.json#/graph"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         },
         {
             "title": "diode",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componenentID.json#/componentID"
-                },
                 "type": {
                     "description": "type of diode",
                     "examples": [
@@ -340,17 +317,6 @@
                 "ifVsVf": {
                     "description": "graph of forward current (If) vs forward voltage (VfTyp)",
                     "$ref": "graph.json#/graph"
-                },
-                "package": {
-                    "description": "package size of resistor",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
@@ -358,14 +324,9 @@
             "title": "bjt",
             "type": "object",
             "required": [
-                "componentID",
                 "channel"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn.",
-                    "$ref": "componenentID.json#/componentID"
-                },
                 "bjtChannelType": {
                     "description": "doping of a transistor's channel - describes whether a transistor is n-type or p-type.",
                     "enum": [
@@ -488,17 +449,6 @@
                     "description": "frequency of unity current gain with a short circuit output (ft)",
                     "$comment": "units of hertz",
                     "$ref": "conditionalProperty.json#/conditionalProperty"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         }

--- a/part-spec/sensor.json
+++ b/part-spec/sensor.json
@@ -7,14 +7,7 @@
         {
             "title": "accelerometer",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "accelerometerType": {
                     "description": "type of accelerometer",
                     "examples": [
@@ -113,31 +106,13 @@
                 "currentConsumption": {
                     "description": "current consumption of a device",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "package size of a device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "gyroscope",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "gyroRanges": {
                     "description": "range of angular speed that gyro can measure",
                     "comment": "units of degrees-per-second (dps)",
@@ -210,31 +185,13 @@
                 "currentConsumption": {
                     "description": "current consumption of a device",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "package size of a device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "magnetic sensor",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "magneticSensingTechnology": {
                     "description": "method by which magnetism is detected",
                     "examples": [
@@ -302,31 +259,13 @@
                 "currentConsumption": {
                     "description": "current consumption of a device",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "package size of a device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "thermal",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "sensingTechnology": {
                     "description": "method by which temperature is detected",
                     "examples": [
@@ -379,17 +318,6 @@
                 "currentConsumption": {
                     "description": "current consumption of a device",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "package size of a device",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/storage_memory.json
+++ b/part-spec/storage_memory.json
@@ -8,14 +8,9 @@
             "title": "ssd",
             "type": "object",
             "required": [
-                "componentID",
                 "capacity"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "type": {
                     "description": "type of ssd storage as defined by interface and technology",
                     "examples": [
@@ -47,17 +42,6 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
@@ -65,14 +49,9 @@
             "title": "sd card",
             "type": "object",
             "required": [
-                "componentID",
                 "capacity"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "type": {
                     "description": "type of sd card",
                     "examples": [
@@ -96,17 +75,6 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
@@ -114,14 +82,9 @@
             "title": "dram",
             "type": "object",
             "required": [
-                "componentID",
                 "capacity"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "type": {
                     "description": "type of dram",
                     "examples": [
@@ -184,31 +147,13 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
         {
             "title": "rom",
             "type": "object",
-            "required": [
-                "componentID"
-            ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "capacity": {
                     "description": "capacity of rom",
                     "comment": "units of bytes (B)",
@@ -230,17 +175,6 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
@@ -248,14 +182,9 @@
             "title": "eeprom",
             "type": "object",
             "required": [
-                "componentID",
                 "capacity"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "capacity": {
                     "description": "capacity/density of eeprom",
                     "comment": "units of bits",
@@ -305,17 +234,6 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         },
@@ -323,14 +241,9 @@
             "title": "flash memory",
             "type": "object",
             "required": [
-                "componentID",
                 "capacity"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "capacity": {
                     "description": "capacity/density of flash memory",
                     "comment": "units of bits",
@@ -405,17 +318,6 @@
                     "description": "current consumption of a device",
                     "comment": "units of amps",
                     "$ref": "currentConsumption.json#/currentConsumption"
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
                 }
             }
         }

--- a/part-spec/usbc.json
+++ b/part-spec/usbc.json
@@ -8,14 +8,9 @@
             "title": "usb-c pd controller",
             "type": "object",
             "required": [
-                "componentID",
                 "pdVersion"
             ],
             "properties": {
-                "componentID": {
-                    "description": "common component identifying information, such as mpn",
-                    "$ref": "componentID.json#/componentID"
-                },
                 "pdVersion": {
                     "description": "version of power delivery spec implemented by controller",
                     "examples": [
@@ -27,8 +22,8 @@
                 "usbTypecRevision": {
                     "description": "usb type-c spec revision implemented by controller",
                     "examples": [
-                         "1.2",
-                         "1.3"
+                        "1.2",
+                        "1.3"
                     ],
                     "type": "string"
                 },
@@ -38,8 +33,8 @@
                         "Source",
                         "Sink",
                         "DRP"
-                     ],
-                     "type": "string"
+                    ],
+                    "type": "string"
                 },
                 "fastRoleSwapSupport": {
                     "description": "whether the pd controller supports fast role swap (FRS)",
@@ -55,7 +50,7 @@
                     "$ref": "unit.json#/unit"
                 },
                 "vconnMaxCurrent": {
-                    "description": "maximum continuous current supported by internal vconn switch (if supported)", 
+                    "description": "maximum continuous current supported by internal vconn switch (if supported)",
                     "comment": "units of amps",
                     "$ref": "unit.json#/unit"
                 },
@@ -71,7 +66,7 @@
                 "integratedLoadSwitch": {
                     "description": "whether the pd controller has one or more integrated load switches ",
                     "type": "boolean"
-                }, 
+                },
                 "maxSinkCurrent": {
                     "description": "maximum continuous current supported by pd controller integrated sink load switch",
                     "comment": "units of amps",
@@ -109,17 +104,6 @@
                 "componentProtectionThresholds": {
                     "description": "Thermal and power supply protection thresholds of a device",
                     "$ref": "componentProtectionThresholds.json#/componentProtectionThresholds"
-                },
-                "pins": {
-                    "description": "array of pin objects with associated properties",
-                    "type": "array",
-                    "items": {
-                        "$ref": "pinSpec.json#/pinSpec"
-                    }
-                },
-                "package": {
-                    "description": "component's package size and description",
-                    "$ref": "package.json#/package"
                 }
             }
         }

--- a/support-docs/examples.md
+++ b/support-docs/examples.md
@@ -2471,6 +2471,200 @@ LED Example - Limited pins
         }
     ]
 }
+```
+
+MCU Example - Limited pins, multiple files
+
+stm32f205RBT6.json (main component file)
+```json
+{
+    "componentID": {
+        "partType": "ic micro",
+        "manufacturer": "ExampleManufacturer",
+        "componentName": "stm32f205RBT6",
+        "orderableMPN": [
+            "stm32f205RBT6xxxTR",
+            "stm32f205RBT6xxx"
+        ],
+        "sourceDatasheetID": {
+            "publishedDate": "2021-05-23",
+            "datasheetURI": "www.Examplemanufacturer.com/stm32datasheet"
+        },
+        "digitalDatasheetID": {
+            "publishedDate": "2022-03-21",
+            "guid": "3e4cd9de-657a-41ae-902e-beca95aff51d"
+        },
+        "status": "active"
+    },
+    "datasheetFiles": {
+        "coreProperties": {
+            "filedescription": "core specifications for stm32f205",
+            "fileType": "json",
+            "fileExtension": "json",
+            "fileURI": "stm32f205_core.json"
+        },
+        "additionalCoreProperties": {
+            "filedescription": "additional property list for parts following the part number: stm32f205xBx6",
+            "fileType": "json",
+            "fileExtension": "json",
+            "fileURI": "stm32f205xBx6.json"
+        },
+        "pins": {
+            "filedescription": "pin specifications for 64 pins",
+            "fileType": "json",
+            "fileExtension": "json",
+            "fileURI": "stm32f205R_pin.json"
+        },
+        "package": {
+            "filedescription": "package specifications for 64 pin LQFP",
+            "fileType": "json",
+            "fileExtension": "json",
+            "fileURI": "stm32f205xxT_package.json"
+        }
+    }
+}
+```
+stm32f205_core.json (core properties file)
+```json
+{
+    "onChipRAM": {
+        "siUnit": "byte",
+        "absoluteValue": 128,
+        "unitText": "KB",
+        "unitFactor": 1e3,
+        "valueDefined": true
+    },
+    "onChipROM": {
+        "siUnit": "byte",
+        "absoluteValue": 1,
+        "unitText": "KB",
+        "unitFactor": 1e3,
+        "valueDefined": true
+    },
+    "coreProcessor": "xyz",
+    "coreArchitectureBits": "32-bit",
+    "clockSpeed": {
+        "siUnit": "hertz",
+        "absoluteValue": 120,
+        "unitText": "MHz",
+        "unitFactor": 1e6,
+        "valueDefined": true
+    },
+    "activePower": {
+        "siUnit": "watt",
+        "absoluteValue": 500,
+        "unitText": "mW",
+        "unitFactor": 1e-3,
+        "valueDefined": true
+    }
+}
+
+```
+
+stm32f205xBx6.json (additional properties file)
+```json
+{
+    "onChipFlash": {
+        "siUnit": "byte",
+        "absoluteValue": 128,
+        "unitText": "KB",
+        "unitFactor": 1e6,
+        "valueDefined": true
+    }
+}
+
+```
+
+stm32f205R_pin.json (pin file)
+```json
+{
+    "pins": [
+        {
+            "terminalIdentifier": "1",
+            "name": "vdd1"
+        },
+        {
+            "terminalIdentifier": "2",
+            "name": "vdd2"
+        },
+        {
+            "terminalIdentifier": "3",
+            "name": "ALERT#/KSI1/I2C1_SCL/GPIO6",
+            "numberOfSupportedFunctions": 4,
+            "functionProperties": [
+                {
+                    "perFunctionName": "ALERT#",
+                    "interfaceType": "interrupt",
+                    "direction": "out",
+                    "electricalConfiguration": "open-drain",
+                    "polarity": "low"
+                },
+                {
+                    "perFunctionName": "KSI1",
+                    "interfaceType": "keyboard",
+                    "pinUsage": "KSI1",
+                    "direction": "in",
+                    "electricalConfiguration": "high-impedance",
+                    "polarity": "low"
+                },
+                {
+                    "perFunctionName": "I2C1_SCL",
+                    "interfaceType": "i2c",
+                    "pinUsage": "I2C_SCL",
+                    "direction": "out",
+                    "electricalConfiguration": "open-drain",
+                    "polarity": "low"
+                },
+                {
+                    "perFunctionName": "GPIO6",
+                    "interfaceType": "gpio",
+                    "direction": "bidir",
+                    "electricalConfiguration": "push-pull"
+                }
+            ],
+            "vihMax": {
+                "siUnit": "volts",
+                "unitText": "V",
+                "unitFactor": 1,
+                "relativeValueReference": "VDD1",
+                "relativeValueModifier": 0.7,
+                "relativeValueOperator": "multiply",
+                "valueDefined": true
+            }
+        }
+    ]
+}
+
+```
+
+stm32f205xxT_package (package file)
+```json
+{
+    "length": {
+        "siUnit": "millimeter",
+        "absoluteValue": 10,
+        "unitText": "mm",
+    },
+    "width": {
+        "siUnit": "millimeter",
+        "absoluteValue": 10,
+        "unitText": "mm",
+    },
+    "height": {
+        "siUnit": "millimeter",
+        "absoluteValue": 1.6,
+        "unitText": "mm",
+    },
+    "partModelInformation":  {
+        "filedescription": "package specifications for 64 pin LQFP",
+        "fileType": "xml",
+        "fileExtension": "xml",
+        "standardReferenced": "IPC2552",
+        "fileURI": "lqfp64.xml"
+    }
+}
+
+```
     
         
     


### PR DESCRIPTION
This re-organizes the way components are organized to reflect the multi-file naming scheme we came up with.