### PR TITLE
Changes for rev1.0

### DIFF
--- a/part-spec/common/componentID.json
+++ b/part-spec/common/componentID.json
@@ -108,8 +108,8 @@
                 },
                 "eDataheetSpecRevision": {
                     "description": "revision of the digital datasheet specifications used to create the digital datasheet",
-                    "example": "rev 1.0",
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["1.0"]
                 },
                 "guid": {
                     "description": "vendor defined guid (see https://www.guidgenerator.com/) to uniquely identify digital datasheet version",

--- a/part-spec/common/componentID.json
+++ b/part-spec/common/componentID.json
@@ -106,6 +106,11 @@
                     "example": "2022-03-31",
                     "type": "string"
                 },
+                "eDataheetSpecRevision": {
+                    "description": "revision of the digital datasheet specifications used to create the digital datasheet",
+                    "example": "rev 1.0",
+                    "type": "string"
+                },
                 "guid": {
                     "description": "vendor defined guid (see https://www.guidgenerator.com/) to uniquely identify digital datasheet version",
                     "type": "string"

--- a/part-spec/common/componentID.json
+++ b/part-spec/common/componentID.json
@@ -106,7 +106,7 @@
                     "example": "2022-03-31",
                     "type": "string"
                 },
-                "eDataheetSpecRevision": {
+                "eDatasheetSpecRevision": {
                     "description": "revision of the digital datasheet specifications used to create the digital datasheet",
                     "type": "string",
                     "enum": ["1.0"]

--- a/part-spec/common/componentProtectionThresholds.json
+++ b/part-spec/common/componentProtectionThresholds.json
@@ -35,7 +35,7 @@
             "type": "object",
             "properties": {
                 "supplyPinName": {
-                    "description": "name of the power supply pin",
+                    "description": "name of the power supply pin or any other pin monitored",
                     "type": "string"
                 },
                 "overVoltageProtectionThresholdRising": {

--- a/part-spec/data_converter/adc.json
+++ b/part-spec/data_converter/adc.json
@@ -84,7 +84,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "string",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/data_converter/adc.json
+++ b/part-spec/data_converter/adc.json
@@ -84,7 +84,7 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "type": "string",
+                "type": "array",
                 "items": {
                     "$ref": "../common/currentConsumption.json#/currentConsumption"
                 }

--- a/part-spec/data_converter/dac.json
+++ b/part-spec/data_converter/dac.json
@@ -74,7 +74,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "string",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/data_converter/dac.json
+++ b/part-spec/data_converter/dac.json
@@ -74,7 +74,7 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "type": "string",
+                "type": "array",
                 "items": {
                     "$ref": "../common/currentConsumption.json#/currentConsumption"
                 }

--- a/part-spec/ic_io/bridge_chip.json
+++ b/part-spec/ic_io/bridge_chip.json
@@ -47,7 +47,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/highspeed_mux.json
+++ b/part-spec/ic_io/highspeed_mux.json
@@ -42,7 +42,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/level_shifter.json
+++ b/part-spec/ic_io/level_shifter.json
@@ -27,7 +27,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/redriver.json
+++ b/part-spec/ic_io/redriver.json
@@ -38,7 +38,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/retimer.json
+++ b/part-spec/ic_io/retimer.json
@@ -68,7 +68,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/usb_bc12.json
+++ b/part-spec/ic_io/usb_bc12.json
@@ -24,6 +24,13 @@
             "deviceMode": {
                 "description": "whether device mode is supported by bc12 chip",
                 "type": "boolean"
+            },
+            "currentConsumption": {
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_io/usbc_pdcontroller.json
+++ b/part-spec/ic_io/usbc_pdcontroller.json
@@ -113,7 +113,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/ic_io/usbc_portcontroller.json
+++ b/part-spec/ic_io/usbc_portcontroller.json
@@ -96,7 +96,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/ic_microcontroller/microcontroller.json
+++ b/part-spec/ic_microcontroller/microcontroller.json
@@ -53,7 +53,7 @@
                 "description": "firmware version of the part",
                 "type": "string"
             },
-             "currentConsumption": {
+            "currentConsumption": {
                 "description": "current used by device in various power modes",
                 "type": "array",
                 "items": {

--- a/part-spec/ic_microcontroller/microcontroller.json
+++ b/part-spec/ic_microcontroller/microcontroller.json
@@ -53,9 +53,12 @@
                 "description": "firmware version of the part",
                 "type": "string"
             },
-            "currentConsumption": {
+             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_misc/audio_codec.json
+++ b/part-spec/ic_misc/audio_codec.json
@@ -54,7 +54,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_misc/speaker_amplifier.json
+++ b/part-spec/ic_misc/speaker_amplifier.json
@@ -50,7 +50,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_misc/tpm.json
+++ b/part-spec/ic_misc/tpm.json
@@ -29,7 +29,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_misc/wlan_module.json
+++ b/part-spec/ic_misc/wlan_module.json
@@ -76,7 +76,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/ic_misc/wwan_module.json
+++ b/part-spec/ic_misc/wwan_module.json
@@ -54,7 +54,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/logic/logic_gate.json
+++ b/part-spec/logic/logic_gate.json
@@ -51,7 +51,10 @@
             },
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/memory/dram.json
+++ b/part-spec/memory/dram.json
@@ -104,9 +104,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/memory/eeprom.json
+++ b/part-spec/memory/eeprom.json
@@ -41,9 +41,11 @@
                 "description": "eeprom clock frequency"
             },
             "currentConsumption": {
-                "$ref": "../common/currentConsumption.json#/currentConsumption",
-                "comment": "units of amps",
-                "description": "current consumption of a device"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "dataRetention": {
                 "description": "maximum number of read and write cycle the part can support",

--- a/part-spec/memory/flash_memory.json
+++ b/part-spec/memory/flash_memory.json
@@ -87,9 +87,11 @@
                 "type": "boolean"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/memory/rom.json
+++ b/part-spec/memory/rom.json
@@ -33,9 +33,11 @@
                 "type": "boolean"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/power/battery_charger.json
+++ b/part-spec/power/battery_charger.json
@@ -169,8 +169,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/power/displaybacklight_driver.json
+++ b/part-spec/power/displaybacklight_driver.json
@@ -43,8 +43,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "integratedFets": {
                 "description": "whether a device contains integrated switching mosfets",

--- a/part-spec/power/linear_regulator.json
+++ b/part-spec/power/linear_regulator.json
@@ -86,8 +86,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/power/load_switch.json
+++ b/part-spec/power/load_switch.json
@@ -91,8 +91,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/power/pmic.json
+++ b/part-spec/power/pmic.json
@@ -21,8 +21,11 @@
                 }
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "componentProtectionThresholds": {
                 "description": "thermal and power supply protection thresholds of a device",

--- a/part-spec/power/switching_regulator.json
+++ b/part-spec/power/switching_regulator.json
@@ -65,9 +65,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             },
             "switchingFrequency": {
                 "description": "switching frequency (fsw) of voltage regulator",

--- a/part-spec/sensor/accelerometer.json
+++ b/part-spec/sensor/accelerometer.json
@@ -119,8 +119,11 @@
                 "type": "number"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/sensor/gyroscope.json
+++ b/part-spec/sensor/gyroscope.json
@@ -85,8 +85,11 @@
                 "type": "number"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/sensor/magnetic_sensor.json
+++ b/part-spec/sensor/magnetic_sensor.json
@@ -80,8 +80,11 @@
                 "$ref": "../common/values.json#/valueOptions"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/sensor/thermal_sensor.json
+++ b/part-spec/sensor/thermal_sensor.json
@@ -65,8 +65,11 @@
                 "type": "number"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/storage/sd_card.json
+++ b/part-spec/storage/sd_card.json
@@ -36,9 +36,11 @@
                 "type": "number"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/storage/ssd.json
+++ b/part-spec/storage/ssd.json
@@ -44,9 +44,11 @@
                 "type": "string"
             },
             "currentConsumption": {
-                "description": "current consumption of a device",
-                "comment": "units of amps",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "description": "current used by device in various power modes",
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false

--- a/part-spec/undefined/undefined_ic.json
+++ b/part-spec/undefined/undefined_ic.json
@@ -7,7 +7,10 @@
         "properties": {
             "currentConsumption": {
                 "description": "current used by device in various power modes",
-                "$ref": "../common/currentConsumption.json#/currentConsumption"
+                "type": "array",
+                "items": {
+                    "$ref": "../common/currentConsumption.json#/currentConsumption"
+                }
             }
         },
         "additionalProperties": false


### PR DESCRIPTION
- Changed currentConsumption property into an array of objects since a component can have multiple supplies.
- Added into componentID.json a property to capture the digital datasheet specification revision referenced to generate an e-datasheet.
-  Initial assumption was that only supply pins required protections like OVP, UVLO. This is not the case. Expanded the definition of a powerSupply in ComponentProtectionThresholds.json file to include any pin (not just supply pins) that is monitored by protection mechanisms. Example, the CC lines in the USB Type-c PD controller may have over voltage protection.