### PR TITLE
Fix component.json thermal references

### DIFF
--- a/part-spec/component.json
+++ b/part-spec/component.json
@@ -72,7 +72,7 @@
 				},
 				"thermal": {
 					"description": "component temperature and thermal resistance information",
-					"$ref": "./common/thermals.json#/thermalProperties"
+					"$ref": "./common/thermal.json#/thermal"
 				},
 				"reliability": {
 					"description": "reliability information about the component",


### PR DESCRIPTION
# Description

PR #112  added the ability to specify register information introduced in #23, but it introduced a typo in the path for the `thermal.json`

## Changes

- [x] fix path `thermals.json` -> `thermal.json`
- [x] fix def `thermalProperties` -> `thermal`

## Contribution checklist
- [x] CLA signed