### PR TITLE
Update pinSpec.json

### DIFF
--- a/part-spec/common/pinSpec.json
+++ b/part-spec/common/pinSpec.json
@@ -200,7 +200,6 @@
         "voltageOptions": {
           "description": "list of voltage levels supported by a pin",
           "comment": "units of volts",
-          "type": "array",
           "items": {
             "$ref": "../common/values.json#/valueOptions"
           }


### PR DESCRIPTION
All attributes are referencing values.json#/valueOptions that is type array. VoltageOptions should follow the same direction.